### PR TITLE
Schedule of talks

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
           <table>
             <thead>
               <tr>
-                <th colspan="3">Thursday</th>
+                <th colspan="3">Thursday - Sessions</th>
               </tr>
             </thead>
             <tbody>
@@ -149,7 +149,7 @@
               </tr>
               <tr>
                 <td>11:10-11:40</td>
-                <td class="session">session - Abe Stanway</td>
+                <td class="session">Abe Stanway</td>
               </tr>
               <tr class="short">
                 <td>11:40-11:55</td>
@@ -157,11 +157,11 @@
               </tr>
               <tr>
                 <td>11:55-12:25</td>
-                <td class="session">session - Theo Schlossnagle</td>
+                <td class="session">Theo Schlossnagle</td>
               </tr>
               <tr>
                 <td>12:30-13:00</td>
-                <td class="session">session - Katherine Daniels</td>
+                <td class="session">Katherine Daniels</td>
               </tr>
               <tr class="tall">
                 <td>13:00-14:30</td>
@@ -169,15 +169,15 @@
               </tr>
               <tr>
                 <td>14:30-15:00</td>
-                <td class="session">session - Lindsay Holmwood</td>
+                <td class="session">Lindsay Holmwood</td>
               </tr>
               <tr>
                 <td>15:05-15:35</td>
-                <td class="session">session - Mark McGranaghan</td>
+                <td class="session">Mark McGranaghan</td>
               </tr>
               <tr>
                 <td>15:40-16:10</td>
-                <td class="session">session - Mikhail Panchenko</td>
+                <td class="session">Mikhail Panchenko</td>
               </tr>
               <tr class="short">
                 <td>16:10-16:25</td>
@@ -185,15 +185,15 @@
               </tr>
               <tr>
                 <td>16:25-16:55</td>
-                <td class="session">session - Jarkko Laine</td>
+                <td class="session">Jarkko Laine</td>
               </tr>
               <tr>
                 <td>17:00-17:30</td>
-                <td class="session">session - Ryan Smith</td>
+                <td class="session">Ryan Smith</td>
               </tr>
               <tr>
                 <td>17:35-18:05</td>
-                <td class="session">session - De Matteis &amp; Wincup</td>
+                <td class="session">Daniele De Matteis &amp; Harry Wincup</td>
               </tr>
               <tr class="tall">
                 <td>19:00-22:00</td>

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -335,7 +335,7 @@ div.signup {
   background-color: rgb(236, 236, 236);
 }
 
-.schedule td.workshop hr {
+.schedule td.session hr, .schedule td.workshop hr {
   border: 0;
   height: 0;
   margin: 4px 0;


### PR DESCRIPTION
I would've preferred to get the Friday sessions and workshops within the same table body and rows, but the times don't match up nicely. The only way I can think that would work is to stop using tables and use fixed height elements instead.

I think we should go with this for now and if it bothers us, look at changing it afterwards. Let's get this published.

@roidrage If you agree, feel free to merge and push before I wake up. Otherwise I'll see you guys in the morning. :smile_cat: 
